### PR TITLE
Improve NetScout reachability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# ReachCheck
+# NetScout
+
+NetScout is a lightweight Python tool for verifying basic network reachability. It can parse targets from IP addresses, CIDR ranges, hostnames or files and will run several checks in parallel:
+
+* ICMP ping
+* TCP connectivity on selected ports
+* UDP probes on selected ports
+* HTTP and HTTPS requests
+
+Results are displayed in a rich terminal table and a Markdown report is produced. Optionally the report can be enhanced via an Ollama server.
+
+## Usage
+
+```bash
+python3 netscout.py <target> [--ports 22 80] [--udp-ports 53 123]
+```
+
+Targets may be single hosts, CIDR ranges or a file containing one target per line.
+
+## Example
+
+```bash
+python3 netscout.py 192.168.1.0/24 --ports 22 80 443 --udp-ports 53
+```
+
+This will test each host in the subnet for ICMP reachability, TCP ports 22/80/443, UDP port 53 and web accessibility over HTTP and HTTPS.

--- a/netscout.py
+++ b/netscout.py
@@ -11,9 +11,13 @@ import requests
 import concurrent.futures
 import time
 from collections import defaultdict
+import urllib3
 
 DEFAULT_TCP_PORTS = [22, 80, 443, 445, 3389]
+DEFAULT_UDP_PORTS = [53, 123]
 console = Console()
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def parse_targets(target):
@@ -59,9 +63,33 @@ def check_tcp_port(host, port):
         return False
 
 
+def check_udp_port(host, port):
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.settimeout(1)
+            s.sendto(b"", (host, port))
+            # attempt to receive a response; timeout implies port open/filtered
+            s.recvfrom(1024)
+        return True
+    except socket.timeout:
+        return True
+    except Exception:
+        return False
+
+
 def check_http(host):
     try:
         response = requests.get(f"http://{host}", timeout=2)
+        return response.status_code < 500
+    except Exception:
+        return False
+
+
+def check_https(host):
+    try:
+        response = requests.get(
+            f"https://{host}", timeout=2, verify=False
+        )
         return response.status_code < 500
     except Exception:
         return False
@@ -71,14 +99,22 @@ def format_report(results):
     report = [
         "# Network Segmentation Test Summary",
         "",
-        "| Host | ICMP | TCP (Ports) | HTTP |",
-        "|------|------|-------------|------|"
+        "| Host | ICMP | TCP (Ports) | UDP (Ports) | HTTP | HTTPS |",
+        "|------|------|-------------|-------------|------|-------|"
     ]
     for host, data in results.items():
         icmp_status = "✅" if data["icmp"] else "❌"
-        tcp_summary = ", ".join(f"{port}:✅" if state else f"{port}:❌" for port, state in data["tcp"].items())
+        tcp_summary = ", ".join(
+            f"{port}:✅" if state else f"{port}:❌" for port, state in data["tcp"].items()
+        )
+        udp_summary = ", ".join(
+            f"{port}:✅" if state else f"{port}:❌" for port, state in data["udp"].items()
+        )
         http_status = "✅" if data["http"] else "❌"
-        report.append(f"| {host} | {icmp_status} | {tcp_summary} | {http_status} |")
+        https_status = "✅" if data["https"] else "❌"
+        report.append(
+            f"| {host} | {icmp_status} | {tcp_summary} | {udp_summary} | {http_status} | {https_status} |"
+        )
     return "\n".join(report)
 
 
@@ -88,7 +124,13 @@ def format_subnet_summary(results):
         try:
             subnet = str(ipaddress.ip_network(host + '/24', strict=False))
             subnet_results[subnet]["total"] += 1
-            if data["icmp"] or any(data["tcp"].values()) or data["http"]:
+            if (
+                data["icmp"]
+                or any(data["tcp"].values())
+                or any(data["udp"].values())
+                or data["http"]
+                or data["https"]
+            ):
                 subnet_results[subnet]["reachable"] += 1
         except ValueError:
             continue
@@ -133,29 +175,38 @@ def enhance_with_ollama(report, ollama_url):
         return report
 
 
-def test_host(host, ports):
-    result = {"icmp": False, "tcp": {}, "http": False}
+def test_host(host, tcp_ports, udp_ports):
+    result = {"icmp": False, "tcp": {}, "udp": {}, "http": False, "https": False}
     result["icmp"] = ping_host(host)
-    for port in ports:
+    for port in tcp_ports:
         result["tcp"][port] = check_tcp_port(host, port)
+    for port in udp_ports:
+        result["udp"][port] = check_udp_port(host, port)
     result["http"] = check_http(host)
+    result["https"] = check_https(host)
     return host, result
 
 
-def display_terminal_table(results, ports):
+def display_terminal_table(results, tcp_ports, udp_ports):
     table = Table(title="Network Segmentation Reachability Results")
     table.add_column("Host", style="cyan", no_wrap=True)
     table.add_column("ICMP", justify="center")
-    for port in ports:
+    for port in tcp_ports:
         table.add_column(f"TCP {port}", justify="center")
+    for port in udp_ports:
+        table.add_column(f"UDP {port}", justify="center")
     table.add_column("HTTP", justify="center")
+    table.add_column("HTTPS", justify="center")
 
     for host, data in results.items():
         row = [host]
         row.append("✅" if data["icmp"] else "❌")
-        for port in ports:
+        for port in tcp_ports:
             row.append("✅" if data["tcp"].get(port) else "❌")
+        for port in udp_ports:
+            row.append("✅" if data["udp"].get(port) else "❌")
         row.append("✅" if data["http"] else "❌")
+        row.append("✅" if data["https"] else "❌")
         table.add_row(*row)
 
     console.print(table)
@@ -165,8 +216,20 @@ def main():
     parser = argparse.ArgumentParser(description="Enhanced Network Segmentation Test Script with Subnet Summary")
     parser.add_argument("target", help="Target IP, CIDR, hostname, or file with list")
     parser.add_argument("--ollama", help="URL of Ollama server (e.g., http://localhost:11434)", default=None)
-    parser.add_argument("--ports", nargs="+", type=int, default=DEFAULT_TCP_PORTS,
-                        help="List of TCP ports to check (default: 22, 80, 443, 445, 3389)")
+    parser.add_argument(
+        "--ports",
+        nargs="+",
+        type=int,
+        default=DEFAULT_TCP_PORTS,
+        help="List of TCP ports to check (default: 22, 80, 443, 445, 3389)",
+    )
+    parser.add_argument(
+        "--udp-ports",
+        nargs="+",
+        type=int,
+        default=DEFAULT_UDP_PORTS,
+        help="List of UDP ports to check (default: 53, 123)",
+    )
     args = parser.parse_args()
 
     targets = parse_targets(args.target)
@@ -174,12 +237,15 @@ def main():
 
     results = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
-        future_to_host = {executor.submit(test_host, host, args.ports): host for host in targets}
+        future_to_host = {
+            executor.submit(test_host, host, args.ports, args.udp_ports): host
+            for host in targets
+        }
         for future in concurrent.futures.as_completed(future_to_host):
             host, result = future.result()
             results[host] = result
 
-    display_terminal_table(results, args.ports)
+    display_terminal_table(results, args.ports, args.udp_ports)
 
     report = format_report(results)
     subnet_summary = format_subnet_summary(results)


### PR DESCRIPTION
## Summary
- add UDP probes and HTTPS checks
- update CLI to accept `--udp-ports`
- display new results in the table and Markdown report
- improve README with usage instructions

## Testing
- `python3 -m py_compile netscout.py`
- `python3 netscout.py --help`
- `python3 netscout.py 127.0.0.1 --ports 22 --udp-ports 53`


------
https://chatgpt.com/codex/tasks/task_e_68493820be9c832b97869b12930664e8