### PR TITLE
Add reachable hosts summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ NetScout is a lightweight Python tool for verifying basic network reachability. 
 
 Results are displayed in a rich terminal table and a Markdown report is produced. Optionally the report can be enhanced via an Ollama server.
 
+The Markdown report now also includes:
+
+* A summary table listing only hosts that responded to at least one check
+* A subnet reachability summary table
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- show which hosts responded to any check
- mention new summaries in README

## Testing
- `python3 -m py_compile netscout.py`
- `python3 netscout.py 127.0.0.1 --ports 22 80 443 > /tmp/test_output.txt && tail -n 20 /tmp/test_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_684943a3f09c832b95b7564e6c92ba56